### PR TITLE
Show provider availabilities

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -37,6 +37,11 @@ layout: default
         {{ person.name }}, {{ person.position }}
       </a>
     </h2>
+    {%- if person.any_availability -%}
+      <p>❎ No availabilities at this time
+    {%- else -%}
+      <p>✅ {{ person.availability }}
+    {%- endif -%}
     <p>{{ person.teaser | escape }}</p>
   </div>
   {%- endfor -%}

--- a/_psychotherapy/aida-manduley.md
+++ b/_psychotherapy/aida-manduley.md
@@ -8,6 +8,7 @@ email: manduley@bu.edu
 image: /assets/people/IMG_6328.jpg
 teaser: For many of us, finding help (or even asking for it) isn’t easy. Whatever your reasons for pursuing counseling/ therapy, my goal is to collaborate with you on the path to wellness and fulfillment.
 insurance: out-of-network, sliding scale, private pay
+any_availability: false
 availability: I currently do not have any openings. Please check back here for updates. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/andreas-neumann-mascis.md
+++ b/_psychotherapy/andreas-neumann-mascis.md
@@ -7,6 +7,7 @@ email: andreasthemeetingpoint@gmail.com
 image: /assets/people/andreas-neumann-mascis.jpg
 teaser: AndreAs does individual and relationship therapy as well as group therapy, training and consultation.
 insurance: Allways, BMC Health Net, Blue Cross Blue Shield, Cigna, Tufts commercial, Harvard Pilgrim Healthcare, Optum, United Healthcare, private pay, sliding scale, out-of-network
+any_availability: false
 return: /psychotherapy/
 ---
 

--- a/_psychotherapy/anna-tarkoff.md
+++ b/_psychotherapy/anna-tarkoff.md
@@ -7,6 +7,7 @@ email: annatarkofflicsw@gmail.com
 image: /assets/people/anna-tarkoff.jpg
 teaser: Anna draws from many different therapeutic styles, with the idea that it is valuable both to know how and why we got here, and to learn how to act differently now.
 insurance: Blue Cross Blue Shield, Tufts commercial, out-of-network, self-pay, sliding scale
+any_availability: false
 availability: At this time, my practice is unfortunately full. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/chris-medeiros.md
+++ b/_psychotherapy/chris-medeiros.md
@@ -8,6 +8,7 @@ email: chrismedeiroscounseling@gmail.com
 image: /assets/people/chris-medeiros.jpg
 teaser: His approach incorporates mindfulness/self-compassion practice, psychodynamic and cognitive behavior therapy, and spiritual development.
 insurance: Blue Cross Blue Shield, Cigna, private pay, out-of-network
+any_availability: true
 availability: I currently have 1pm available on Mondays and Thursdays, please reach out to me directly to set up an initial consultation.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/clare-mcbee.md
+++ b/_psychotherapy/clare-mcbee.md
@@ -7,6 +7,7 @@ email: claremcbee.licsw@gmail.com
 image: /assets/people/clare-mcbee.jpg
 insurance: Blue Cross Blue Shield, Tufts commercial, Cigna, Allways, Aetna, Tufts Health Together, Tufts Health Direct, Optum, United Healthcare, self-pay, sliding scale
 teaser: I’m a firm believer that a person will not feel safe exploring difficult areas in therapy if they don’t feel comfortable with and understand the human sitting across from them.
+any_availability: false
 availability: At this time, my practice is unfortunately full and I cannot offer a waitlist. But please feel free to get in touch if you are interested in an update. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/dawn-belkin-martinez.md
+++ b/_psychotherapy/dawn-belkin-martinez.md
@@ -7,6 +7,7 @@ phone: (781)-462-1265
 email: dawnbelkin@gmail.com
 teaser: Dawn has extensive experience working with immigrants and marginalized communities and is one of the founding members of the Boston Liberation Health Group
 insurance: self-pay, sliding scale
+any_availability: false
 availability: At this time, my practice is unfortunately full. In general, I only see clients on Fridays, between 2pm and 6pm.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/dennie-butler-mackay.md
+++ b/_psychotherapy/dennie-butler-mackay.md
@@ -7,6 +7,7 @@ email: dennieatthemeetingpoint@gmail.com
 image: /assets/people/dennie-butler-mackay.jpg
 teaser: While Dennie draws primarily on her certification as a sensorimotor psychotherapist, her training, skillset, and intuition is grounded in a variety of other traditional and nontraditional healing approaches.
 insurance: out-of-network, self-pay, sliding scale
+any_availability: true
 availability: I am offering appointments on Saturdays. Please contact me for current openings. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/fatimah-finney.md
+++ b/_psychotherapy/fatimah-finney.md
@@ -7,6 +7,7 @@ email: Fatimah.LMHC@gmail.com
 image:
 teaser: I am trained as a Level 1 Internal Family Systems therapist, and I fundamentally believe that healing begins with a healthy attachment to your inner self.
 insurance: Blue Cross Blue Shield, Harvard Pilgrim Healthcare, United Healthcare, self-pay, sliding scale
+any_availability: false
 availability: I see clients on Wednesdays & Thursdays (afternoons/evenings), and Saturdays (morning/early afternoon). However, at this time my practice is unfortunately full.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/karen-enegess.md
+++ b/_psychotherapy/karen-enegess.md
@@ -8,6 +8,7 @@ email: Karen@HolisticPsychotherapyCenter.com
 image: /assets/people/karen-enegess.jpg
 teaser: My approach is collaborative, strengths-based, and holistic, that is, I see you as a whole person, and believe in the interconnectedness of body, mind and spirit.
 insurance: Allways, Blue Cross Blue Shield, Harvard Pilgrim Healthcare, Optum, United Healthcare, Tufts commercial, private pay, sliding scale
+any_availability: false
 availability: At this time, my practice is unfortunately full. But please feel free to get in touch if you are interested in an update.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/karen-gore.md
+++ b/_psychotherapy/karen-gore.md
@@ -7,6 +7,7 @@ email: kgorelicsw@gmail.com
 image:
 teaser: Wren believes in the empowerment of therapy to help you thrive. She is engaged in and supportive of the LGBTQ community.
 insurance: Blue Cross Blue Shield, Harvard Pilgrim Healthcare, United Healthcare, self-pay, sliding scale, out-of-network
+any_availability: false
 availability: At this time, my practice is unfortunately full.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/leah-soumerai.md
+++ b/_psychotherapy/leah-soumerai.md
@@ -7,6 +7,7 @@ email: leahsoumerai@gmail.com
 image:
 teaser: I have specialized training in trauma-focused therapy, cognitive behavioral therapy and internal family systems therapy.
 insurance: Blue Cross Blue Shield, out-of-network, self-pay, sliding scale
+any_availability: false
 availability: At this time, my practice is unfortunately full. But please feel free to get in touch if you are interested in an update.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/margot-meitner.md
+++ b/_psychotherapy/margot-meitner.md
@@ -8,6 +8,7 @@ email: margot@margotmeitner.com
 image: /assets/people/margot-meitner.jpg
 teaser: Margot brings a warm and interactive style to her psychotherapeutic practice, which can best be described as “eclectic,” as she believes that not one type of therapy is right for everyone.
 insurance: out-of-network, self-pay, sliding scale
+any_availability: true
 availability: I am available on Tuesdays and Thursdays for appointments. I am also taking referrals for lifecycle ritual officiation such as weddings, baby namings, and transition rituations. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/marlo-pedroso.md
+++ b/_psychotherapy/marlo-pedroso.md
@@ -8,6 +8,7 @@ email: emergenceprojectboston@gmail.com
 image: /assets/people/marlo-pedroso.jpg
 teaser: Marlo has has trained extensively in evidence based approaches, and unites that knowledge with deep spiritual understand and a creative flair.
 insurance: Allways, Blue Cross Blue Shield, United Healthcare, Optum, self-pay, sliding scale, out-of-network
+any_availability: false
 availability: I have a waitlist and am happy to add clients who feel like we would be a good match and don't have urgent needs.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/melissa-macNish-nishman.md
+++ b/_psychotherapy/melissa-macNish-nishman.md
@@ -8,6 +8,7 @@ email: melissa@sayftee.com
 image: /assets/people/Midi_edit.jpg
 teaser: She believes strongly in the power of the therapeutic relationship to create a safe space for individuals, couples and families to explore patterns and the new possibilities that begin to emerge.
 insurance: Blue Cross Blue Shield, self-pay, out-of-network  
+any_availability: true
 availability: Melissa is only accepting referrals for couples and families.
 return: /psychotherapy/
 ---

--- a/_psychotherapy/robin-haas.md
+++ b/_psychotherapy/robin-haas.md
@@ -7,6 +7,7 @@ email: robin.haas26@gmail.com
 image: /assets/people/robin-haas.jpg
 teaser: Robin has done extensive work with those struggling with eating disorders, depression, anxiety, trauma, grief and loss, adoption, separation and divorce, child custody, learning disabilities, sensory motor issues, coming out, questioning identity, and life adjustment issues.
 insurance: Blue Cross Blue Shield, Cigna, out-of-network, private pay, sliding scale
+any_availability: false
 availability: At this time, my practice is unfortunately full. But please feel free to get in touch if you are interested in an update. 
 return: /psychotherapy/
 ---

--- a/_psychotherapy/shannon-mccarthy.md
+++ b/_psychotherapy/shannon-mccarthy.md
@@ -6,6 +6,7 @@ phone: 617-524-4666
 image:
 teaser: My expertise is in counseling people through crisis, trauma and other life transitions by helping them claim their personal power so they can become more fully themselves.
 insurance: Allways, Blue Cross Blue Shield, United Healthcare, Optum, Harvard Pilgrim Healthcare, Tufts commercial, private pay, sliding scale, out-of-network
+any_availability: false
 availability: At this time, my practice is unfortunately full. 
 return: /psychotherapy/
 ---


### PR DESCRIPTION
Currently, prospective clients have to click each provider's page individually to determine who, if anyone, has availabilities.

This change shows a line of text saying either "❎ No availabilities at this time" or a check (✅) followed by the provider's availabilities. (As specified on the individual provider pages in the `_psychotherapy` directory.)

This change also adds an `any_availability` variable to each provider; I filled in the values as best I could infer based on the `availability` fields.

User story:
As a: prospective patient
I want: to know which providers have availabilities without opening 20 new tabs
So that: I can quickly determine if it's worth anyone's time to send an email